### PR TITLE
fix: ensure the definition of the hook ngOnChanges if the corresponding observable is used. See https://stackoverflow.com/a/77930589/2398593

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Here's an example component that hooks onto the full set of available hooks.
 ```ts
 // ./src/app/child/child.component.ts
 
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { getObservableLifecycle } from 'ngx-observable-lifecycle';
 
 @Component({
@@ -93,7 +93,7 @@ import { getObservableLifecycle } from 'ngx-observable-lifecycle';
   templateUrl: './child.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ChildComponent {
+export class ChildComponent implements OnChanges {
   @Input() input1: number | undefined | null;
   @Input() input2: string | undefined | null;
 
@@ -134,6 +134,11 @@ export class ChildComponent {
       changes.input2?.previousValue; // `string | null | undefined`
     });
   }
+
+  // when using the ngOnChanges hook, you have to define the hook in your class even if it's empty
+  // See https://stackoverflow.com/a/77930589/2398593 for more info
+  // eslint-disable-next-line @angular-eslint/no-empty-lifecycle-method
+  public ngOnChanges() {}
 }
 
 ```

--- a/projects/ngx-observable-lifecycle/src/lib/ngx-observable-lifecycle.ts
+++ b/projects/ngx-observable-lifecycle/src/lib/ngx-observable-lifecycle.ts
@@ -67,6 +67,12 @@ type PatchedComponentInstance<Hooks extends LifecycleHookKey = any> = Pick<AllHo
 };
 
 function getSubjectForHook(componentInstance: PatchedComponentInstance, hook: LifecycleHookKey): Subject<void> {
+  if (hook === 'ngOnChanges' && !componentInstance.constructor.prototype[hook]) {
+    throw new Error(
+      `When using the ngOnChanges hook, you have to define the hook in your class even if it's empty. See https://stackoverflow.com/a/77930589/2398593`,
+    );
+  }
+
   if (!componentInstance[hookSubject]) {
     componentInstance[hookSubject] = {};
   }

--- a/src/app/child/child.component.ts
+++ b/src/app/child/child.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { getObservableLifecycle } from 'ngx-observable-lifecycle';
 
 @Component({
@@ -6,7 +6,7 @@ import { getObservableLifecycle } from 'ngx-observable-lifecycle';
   templateUrl: './child.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ChildComponent {
+export class ChildComponent implements OnChanges {
   @Input() input1: number | undefined | null;
   @Input() input2: string | undefined | null;
 
@@ -47,4 +47,9 @@ export class ChildComponent {
       changes.input2?.previousValue; // `string | null | undefined`
     });
   }
+
+  // when using the ngOnChanges hook, you have to define the hook in your class even if it's empty
+  // See https://stackoverflow.com/a/77930589/2398593 for more info
+  // eslint-disable-next-line @angular-eslint/no-empty-lifecycle-method
+  public ngOnChanges() {}
 }


### PR DESCRIPTION
BREAKING CHANGE:
Make sure to define the ngOnChanges hook on your component if you use the ngOnChanges observable given by the library otherwise it'll throw a runtime error. More info about why here https://stackoverflow.com/a/77930589/2398593